### PR TITLE
Updated Target Resources with Newer Examples

### DIFF
--- a/content/concepts/targets.md
+++ b/content/concepts/targets.md
@@ -65,6 +65,6 @@ The example above will create a `lib.js` and `lib.node.js` file in your `dist` f
 As seen from the options above there are multiple different deployment _targets_ that you can choose from. Below is a list of examples, and resources that you can refer to.
 
 *  **[compare-webpack-target-bundles](https://github.com/TheLarkInn/compare-webpack-target-bundles)**: A great resource for testing and viewing different webpack _targets_. Also great for bug reporting.
-* **[Build to both electron.js and browser targets using webpack](https://medium.com/@ad_harmonium/build-to-both-electron-js-and-browser-targets-using-webpack-59266bdb76a)**: An example of a build process using multiple deployment targets with electron and web.
+* **[Boilerplate of Electron-React Application](https://github.com/chentsulin/electron-react-boilerplate)**: A good example of a build process for electron's main process and renderer process.
 
 ?> Need to find up to date examples of these webpack targets being used in live code or boilerplates.


### PR DESCRIPTION
Removed the example of a Webpack setup for building to both electron and web because it uses an old plugin for electron-renderer support even though Webpack has native support for target.

Added example boilerplate which contains good examples of configuration files for both electron-main and electron-renderer